### PR TITLE
Fix compilation errors in newer Linux kernels. Fixes #2.

### DIFF
--- a/libspeedhack.cpp
+++ b/libspeedhack.cpp
@@ -137,7 +137,7 @@ static timespec
 	_monotoniczero, _monotoniccoarsezero, _monotonicrawzero,
 	_boottimezero, _processzero, _threadzero;
 
-static int (*gettimeofday_orig)(timeval *tv, struct timezone *tz);
+static int (*gettimeofday_orig)(timeval *tv, void *tz);
 static int (*clock_gettime_orig)(clockid_t clk_id, timespec *tp);
 
 static double speedup = 1;
@@ -219,7 +219,7 @@ extern "C" void init_libspeedhack()
 	fix_timescale();
 }
 
-extern "C" int gettimeofday(timeval *tv, struct timezone *tz)
+extern "C" int gettimeofday(timeval *tv, void *tz)
 {
 	if (!inited)
 		init_libspeedhack();


### PR DESCRIPTION
The current repo seems to expect an older function signature for sys/time.h.
This patch makes the signature match newer versions, allowing it to compile (tested for Linux kernel 5.10).

(Thanks for the useful tool!)